### PR TITLE
SimpleJSON

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setup(
         'Topic :: Office/Business :: Financial'
     ],
     packages=find_packages("src"),
+    install_requires=['simplejson'],
     package_dir={'': 'src'}
 )

--- a/src/bitcoinrpc/proxy.py
+++ b/src/bitcoinrpc/proxy.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     import httplib
 import base64
-import json
+import simplejson as json
 import decimal
 try:
     import urllib.parse as urlparse


### PR DESCRIPTION
Added simplejson dependency for use in proxy.py.  Simplejson comes with support to encode Decimal objects.  This allows bitcoin-python rpc calls to use the output of other bitcoin-python rpc calls directly, for instance using the output of listunspent as input for createrawtransaction.